### PR TITLE
Add `add_prefix` option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ gem install fluent-plugin-filter-kv-parser
   filtered_keys akey,bkey,ckey
   filtered_keys_regex /^sub_[a-zA-Z_0-9]+/
   filter_out_lines_without_keys false
+  add_prefix my_prefix.
 </filter>
 
 <match **>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gem install fluent-plugin-filter-kv-parser
   filtered_keys akey,bkey,ckey
   filtered_keys_regex /^sub_[a-zA-Z_0-9]+/
   filter_out_lines_without_keys false
-  add_prefix keys_prefix
+  keys_prefix prefix
 </filter>
 
 <match **>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gem install fluent-plugin-filter-kv-parser
   filtered_keys akey,bkey,ckey
   filtered_keys_regex /^sub_[a-zA-Z_0-9]+/
   filter_out_lines_without_keys false
-  add_prefix my_prefix.
+  add_prefix keys_prefix
 </filter>
 
 <match **>

--- a/lib/fluent/plugin/filter_key_value_parser.rb
+++ b/lib/fluent/plugin/filter_key_value_parser.rb
@@ -15,7 +15,7 @@ module Fluent
     config_param :filtered_keys, :string, default: nil
     config_param :filtered_keys_regex, :string, default: nil
     config_param :filtered_keys_delimiter, :string, default: ','
-    config_param :add_prefix, :string, default: nil
+    config_param :keys_prefix, :string, default: nil
 
 
     def configure(conf)
@@ -59,7 +59,7 @@ module Fluent
       keys = @use_regex ? regex_filter(line) : delimiter_filter(line)
       filtered_keys = @filtered_keys_list.empty? ? keys : keys.slice(*@filtered_keys_list)
       filtered_keys = @filtered_keys_regex.nil? ? filtered_keys : filtered_keys.merge(keys.select{ |k,v| @filtered_keys_regex.match(k.to_s)})
-      @add_prefix.nil? ? filtered_keys : filtered_keys.transform_keys!{ |key| "#{@add_prefix}.#{key}" }
+      @keys_prefix.nil? ? filtered_keys : filtered_keys.transform_keys!{ |key| "#{@keys_prefix}.#{key}" }
     end
 
     def delimiter_filter(line)

--- a/lib/fluent/plugin/filter_key_value_parser.rb
+++ b/lib/fluent/plugin/filter_key_value_parser.rb
@@ -15,6 +15,7 @@ module Fluent
     config_param :filtered_keys, :string, default: nil
     config_param :filtered_keys_regex, :string, default: nil
     config_param :filtered_keys_delimiter, :string, default: ','
+    config_param :add_prefix, :string, default: nil
 
 
     def configure(conf)
@@ -57,7 +58,8 @@ module Fluent
     def extracted_keys(line)
       keys = @use_regex ? regex_filter(line) : delimiter_filter(line)
       filtered_keys = @filtered_keys_list.empty? ? keys : keys.slice(*@filtered_keys_list)
-      @filtered_keys_regex.nil? ? filtered_keys : filtered_keys.merge(keys.select{ |k,v| @filtered_keys_regex.match(k.to_s)})
+      filtered_keys = @filtered_keys_regex.nil? ? filtered_keys : filtered_keys.merge(keys.select{ |k,v| @filtered_keys_regex.match(k.to_s)})
+      @add_prefix.nil? ? filtered_keys : filtered_keys.transform_keys!{ |key| @add_prefix + key }
     end
 
     def delimiter_filter(line)

--- a/lib/fluent/plugin/filter_key_value_parser.rb
+++ b/lib/fluent/plugin/filter_key_value_parser.rb
@@ -59,7 +59,7 @@ module Fluent
       keys = @use_regex ? regex_filter(line) : delimiter_filter(line)
       filtered_keys = @filtered_keys_list.empty? ? keys : keys.slice(*@filtered_keys_list)
       filtered_keys = @filtered_keys_regex.nil? ? filtered_keys : filtered_keys.merge(keys.select{ |k,v| @filtered_keys_regex.match(k.to_s)})
-      @add_prefix.nil? ? filtered_keys : filtered_keys.transform_keys!{ |key| @add_prefix + key }
+      @add_prefix.nil? ? filtered_keys : filtered_keys.transform_keys!{ |key| "#{@add_prefix}.#{key}" }
     end
 
     def delimiter_filter(line)

--- a/test/test_filter_key_value_parser.rb
+++ b/test/test_filter_key_value_parser.rb
@@ -216,7 +216,7 @@ class KeyValueFilterTest < Test::Unit::TestCase
   test 'test_add_prefix' do
     d = create_driver(%[
         key log
-        add_prefix test.
+        add_prefix test
       ])
     msg = {
       'time'      => '2013-02-12 22:01:15 UTC',

--- a/test/test_filter_key_value_parser.rb
+++ b/test/test_filter_key_value_parser.rb
@@ -212,4 +212,18 @@ class KeyValueFilterTest < Test::Unit::TestCase
     assert_equal 4, filtered.first[2].count
     assert_equal "10", filtered.first[2]['akey']
   end
+
+  test 'test_add_prefix' do
+    d = create_driver(%[
+        key log
+        add_prefix test.
+      ])
+    msg = {
+      'time'      => '2013-02-12 22:01:15 UTC',
+      'log'      => 'Start Request key=10 akey=20 zkey=30 dkey=40',
+    }
+    filtered = filter(d, [msg]).first[2]
+    assert_equal false,  filtered.key?("key")
+    assert_equal true,  filtered.key?("test.key")
+  end
 end

--- a/test/test_filter_key_value_parser.rb
+++ b/test/test_filter_key_value_parser.rb
@@ -213,10 +213,10 @@ class KeyValueFilterTest < Test::Unit::TestCase
     assert_equal "10", filtered.first[2]['akey']
   end
 
-  test 'test_add_prefix' do
+  test 'test_keys_prefix' do
     d = create_driver(%[
         key log
-        add_prefix test
+        keys_prefix test
       ])
     msg = {
       'time'      => '2013-02-12 22:01:15 UTC',


### PR DESCRIPTION
Hi,

for my use case I needed to add a prefix to the keys of all processed fields (like the `inject_key_prefix` option for parsers).
Now you can add the `add_prefix` option with a string, which will be added as prefix to all keys.

**Example:**

Input: `{"log": "akey=20 bkey=30 ckey=40"}`

Config:
```
<filter **>
  @type key_value_parser
  key log
  use_regex true
  remove_key true
  keys_delimiter /\s+/
  kv_delimiter_char '='
  add_prefix 'test.'
</filter>
```

Output: `{"test.akey": "20",  "test.bkey": "30", "test.ckey": "40"}`

Since I'm a total newbie with Ruby feel free to suggest necessary changes :)